### PR TITLE
Added support for IpV6 DNS server

### DIFF
--- a/src/Heijden.Dns/Heijden.Dns.csproj
+++ b/src/Heijden.Dns/Heijden.Dns.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Header.cs" />
+    <Compile Include="IpV6Extensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Question.cs" />
     <Compile Include="RecordReader.cs" />

--- a/src/Heijden.Dns/IpV6Extensions.cs
+++ b/src/Heijden.Dns/IpV6Extensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Heijden.DNS
+{
+	internal static class IpV6Extensions
+	{
+		public static void DisableIpV6Only(this Socket socket)
+		{
+			try
+			{
+				// This operation throws when running on mono since it is off by default
+				socket.SetSocketOption(SocketOptionLevel.IPv6, (SocketOptionName)27, false);
+			}
+			catch { }
+		}
+
+		public static IPAddress ConvertIpToUnifiedIpv6(IPAddress address)
+		{
+			if (address.AddressFamily == AddressFamily.InterNetworkV6)
+				return address;
+			else if (address.AddressFamily == AddressFamily.InterNetwork)
+				return IPAddress.Parse("::FFFF:" + address.ToString());
+			else
+				throw new InvalidOperationException("This AddressFamily is not supported.");
+		}
+
+	}
+}


### PR DESCRIPTION
When a system configured IPv6 dns server is used the resolver will crash since both sockets are not configured to accept IPv6 addresses.
I know this can be easily fixed by manually specifying a dns server, but the library defaults to all dns addresses found in the system settings so I think simply allowing Ipv6 addresses is the better way.

With .NET Framework 4.5 there is an Option [DualMode](https://msdn.microsoft.com/en-us/library/system.net.sockets.socket.dualmode(v=vs.110).aspx), but unfortunately this project only uses 3.5 so there is no nicer way to handle this.