### PR TITLE
Added separate .NET Standard 2.0 solution and project. Connected to #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/src/Heijden.Dns.Standard.sln
+++ b/src/Heijden.Dns.Standard.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Heijden.Dns.Standard", "Heijden.Dns.Standard\Heijden.Dns.Standard.csproj", "{8D9556FB-F3AB-4148-A212-5B60A56282B3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8D9556FB-F3AB-4148-A212-5B60A56282B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D9556FB-F3AB-4148-A212-5B60A56282B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D9556FB-F3AB-4148-A212-5B60A56282B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D9556FB-F3AB-4148-A212-5B60A56282B3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {59BAE87C-6E53-499E-9137-94AF40CD2F1A}
+	EndGlobalSection
+EndGlobal

--- a/src/Heijden.Dns.Standard/Heijden.Dns.Standard.csproj
+++ b/src/Heijden.Dns.Standard/Heijden.Dns.Standard.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyName>Heijden.Dns</AssemblyName>
+    <RootNamespace>Heijden.Dns</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../Heijden.Dns/**/*.cs" Exclude="../Heijden.Dns/obj/**/*.cs" />
+    <Content Include="../Heijden.Dns/**/*.txt" Exclude="../Heijden.Dns/obj/**/*.txt;../Heijden.Dns/bin/**/*.txt" />
+  </ItemGroup>
+
+</Project>

--- a/src/Heijden.Dns/Resolver.cs
+++ b/src/Heijden.Dns/Resolver.cs
@@ -8,8 +8,9 @@ using System.Net.Sockets;
 using System.Net.NetworkInformation;
 
 using System.Diagnostics;
+#if !NETSTANDARD2_0
 using System.Runtime.Remoting.Messaging;
-
+#endif
 
 /*
  * Network Working Group                                     P. Mockapetris
@@ -661,6 +662,7 @@ namespace Heijden.DNS
 			return entry.AddressList;
 		}
 
+#if !NETSTANDARD2_0
 		private delegate IPAddress[] GetHostAddressesDelegate(string hostNameOrAddress);
 
 		/// <summary>
@@ -697,6 +699,7 @@ namespace Heijden.DNS
 			GetHostAddressesDelegate g = (GetHostAddressesDelegate)aResult.AsyncDelegate;
 			return g.EndInvoke(AsyncResult);
 		}
+#endif
 
 		/// <summary>
 		///		Creates an System.Net.IPHostEntry instance from the specified System.Net.IPAddress.
@@ -728,6 +731,7 @@ namespace Heijden.DNS
 			return MakeEntry(hostName);
 		}
 
+#if !NETSTANDARD2_0
 		private delegate IPHostEntry GetHostByNameDelegate(string hostName);
 
 		/// <summary>
@@ -760,6 +764,7 @@ namespace Heijden.DNS
 			GetHostByNameDelegate g = (GetHostByNameDelegate)aResult.AsyncDelegate;
 			return g.EndInvoke(AsyncResult);
 		}
+#endif
 
 		/// <summary>
 		///		Resolves a host name or IP address to an System.Net.IPHostEntry instance.
@@ -772,6 +777,7 @@ namespace Heijden.DNS
 			return MakeEntry(hostName);
 		}
 
+#if !NETSTANDARD2_0
 		private delegate IPHostEntry ResolveDelegate(string hostName);
 		
 		/// <summary>
@@ -808,6 +814,7 @@ namespace Heijden.DNS
 			ResolveDelegate g = (ResolveDelegate)aResult.AsyncDelegate;
 			return g.EndInvoke(AsyncResult);
 		}
+#endif
 		#endregion
 
 		/// <summary>
@@ -844,6 +851,7 @@ namespace Heijden.DNS
 				return MakeEntry(hostNameOrAddress);
 		}
 
+#if !NETSTANDARD2_0
 		private delegate IPHostEntry GetHostEntryViaIPDelegate(IPAddress ip);
 		private delegate IPHostEntry GetHostEntryDelegate(string hostNameOrAddress);
 
@@ -911,6 +919,7 @@ namespace Heijden.DNS
 			}
 			return null;
 		}
+#endif
 
 		private enum RRRecordStatus
 		{


### PR DESCRIPTION
Begin/End APM methods in class Resolver use AsyncResult class from System.Runtime.Remoting.Messaging namespace. Since .NET Remoting is not available on .NET Standard, these methods are excluded from the .NET Standard project.